### PR TITLE
Explicit global definition

### DIFF
--- a/skycons.js
+++ b/skycons.js
@@ -1,5 +1,3 @@
-var Skycons;
-
 (function(global) {
   "use strict";
 
@@ -524,7 +522,7 @@ var Skycons;
     }
   }
 
-  Skycons = function(opts) {
+  var Skycons = global.Skycons = function(opts) {
     this.list        = [];
     this.interval    = null;
     this.color       = opts && opts.color ? opts.color : "black";


### PR DESCRIPTION
Some script bundlers such as Browserify compile a wrapper function over the modules. If var-statement is used to define the Skycons global it will be hidden inside it and there will be no way to access it.

Use the global object to define the Skycons global explicitly.
