### PR TITLE
Added function that returns icon function based on string

### DIFF
--- a/skycons.js
+++ b/skycons.js
@@ -711,6 +711,46 @@
         cancelInterval(this.interval);
         this.interval = null;
       }
+    },
+    icon: function(name) {
+      var iconFunction;
+
+      switch(name) {
+        case 'clear-day':
+          iconFunction = Skycons.CLEAR_DAY;
+          break;
+        case 'clear-night':
+          iconFunction = Skycons.CLEAR_NIGHT;
+          break;
+        case 'rain':
+          iconFunction = Skycons.RAIN;
+          break;
+        case 'snow':
+          iconFunction = Skycons.SNOW;
+          break;
+        case 'sleet':
+          iconFunction = Skycons.SLEET;
+          break;
+        case 'wind':
+          iconFunction = Skycons.WIND;
+          break;
+        case 'fog':
+          iconFunction = Skycons.FOG;
+          break;
+        case 'cloudy':
+          iconFunction = Skycons.CLOUDY;
+          break;
+        case 'partly-cloudy-day':
+          iconFunction = Skycons.PARTLY_CLOUDY_DAY;
+          break;
+        case 'partly-cloudy-night':
+          iconFunction = Skycons.PARTLY_CLOUDY_NIGHT;
+          break;
+        default:
+          iconFunction = Skycons.CLEAR_DAY;
+          break;
+      }
+      return iconFunction;
     }
   };
 


### PR DESCRIPTION
I was recently using the forecast.io API and stumbled upon this sweet icon set for it. However, I was kind of surprised that I couldn't directly use the icon value from the returned JSON from the API in this library. I added a function that accepts a string, and based on the icon value from the forecast.io API returns the appropriate icon function from this library.
