### PR TITLE
Problem with the addition icons

### DIFF
--- a/skycons.js
+++ b/skycons.js
@@ -711,6 +711,46 @@
         cancelInterval(this.interval);
         this.interval = null;
       }
+    },
+    icon: function(name) {
+      var iconFunction;
+
+      switch(name) {
+        case 'clear-day':
+          iconFunction = Skycons.CLEAR_DAY;
+          break;
+        case 'clear-night':
+          iconFunction = Skycons.CLEAR_NIGHT;
+          break;
+        case 'rain':
+          iconFunction = Skycons.RAIN;
+          break;
+        case 'snow':
+          iconFunction = Skycons.SNOW;
+          break;
+        case 'sleet':
+          iconFunction = Skycons.SLEET;
+          break;
+        case 'wind':
+          iconFunction = Skycons.WIND;
+          break;
+        case 'fog':
+          iconFunction = Skycons.FOG;
+          break;
+        case 'cloudy':
+          iconFunction = Skycons.CLOUDY;
+          break;
+        case 'partly-cloudy-day':
+          iconFunction = Skycons.PARTLY_CLOUDY_DAY;
+          break;
+        case 'partly-cloudy-night':
+          iconFunction = Skycons.PARTLY_CLOUDY_NIGHT;
+          break;
+        default:
+          iconFunction = Skycons.CLEAR_DAY;
+          break;
+      }
+      return iconFunction;
     }
   };
 


### PR DESCRIPTION
I have a problem with icons if more than two, simplicity shows the second.
Example: 
&#60;canvas id="fog" width="64" height="64"&#62;
&#60;/canvas&#62;
&#60;canvas id="fog" width="64" height="64"&#62;
&#60;/canvas&#62;

&#60;script src="skycons.js"&#62;&#60;/script&#62;

  &#60;script&#62;
      var icons = new Skycons();

```
  icons.set("clear-day", Skycons.CLEAR_DAY);
  icons.set("clear-night", Skycons.CLEAR_NIGHT);
  icons.set("partly-cloudy-day", Skycons.PARTLY_CLOUDY_DAY);
  icons.set("partly-cloudy-night", Skycons.PARTLY_CLOUDY_NIGHT);
  icons.set("cloudy", Skycons.CLOUDY);
  icons.set("rain", Skycons.RAIN);
  icons.set("sleet", Skycons.SLEET);
  icons.set("snow", Skycons.SNOW);
  icons.set("wind", Skycons.WIND);
  icons.set("fog", Skycons.FOG);

  icons.play();
</script>
```

Any suggestion? How to show more of one icons with same name.
