### PR TITLE
fixed passing animation functions to 'add()' not working

### DIFF
--- a/skycons.js
+++ b/skycons.js
@@ -639,6 +639,8 @@
       if(typeof draw === "string") {
         draw = draw.toUpperCase().replace(/-/g, "_");
         return Skycons.hasOwnProperty(draw) ? Skycons[draw] : null;
+      } else {
+        return draw;
       }
     },
     add: function(el, draw) {


### PR DESCRIPTION
Passing animation functions by reference like `skycon.add(canvas, Skycons.RAIN)` was not working. This patch fixes it.
